### PR TITLE
feat: add ExecuTorch Vulkan backend support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,17 +84,26 @@ This project utilizes the following inference engines and versions:
   - onnxruntime-genai: [v0.10.0](https://github.com/microsoft/onnxruntime-genai/releases/tag/v0.10.0)
   - onnxruntime: [v1.23.2](https://github.com/microsoft/onnxruntime/releases/tag/v1.23.2)
 
-- **ExecuTorch:** [v0.7.0](https://github.com/pytorch/executorch/releases/tag/v0.7.0)
+- **ExecuTorch:** [v1.0.0](https://github.com/pytorch/executorch/releases/tag/v1.0.0)
 
 - **MediaPipe (LiteRT):** [v0.10.26](https://github.com/google-ai-edge/mediapipe/releases/tag/v0.10.26)
+
+## Hardware Acceleration
+
+### GPU
+
+#### ExecuTorch Vulkan Backend
+
+ExecuTorch provides GPU acceleration through its [Vulkan Backend](https://docs.pytorch.org/executorch/1.0/backends/vulkan/vulkan-overview.html).
+
+As detailed in [How ExecuTorch Works](https://docs.pytorch.org/executorch/1.0/intro-how-it-works.html), achieving hardware acceleration requires an offline compilation step. This process targets a specific hardware backend (like Vulkan). The output is a specialized `.pte` model file compiled explicitly for that backend.
+
+The [ExportRecipe_Llama-3.2-1B_Vulkan_Backend_Instruct.ipynb](docs/notebooks/ExportRecipe_Llama-3.2-1B_Vulkan_Backend_Instruct.ipynb) notebook provides a practical example. It shows the commands needed to convert the `Llama-3.2-1B` model into a `.pte` file tailored for the Vulkan backend.
 
 ## Current Limitations
 
 - **Stateless Conversations:** The context of multi-turn conversations is not preserved; each interaction is a new session.
-
 - **Text-Only:** The app does not handle multimodal inputs.
-
-- **No Hardware Acceleration:** The current version does not include optimizations for specific hardware backends.
 
 ## References
 

--- a/docs/notebooks/ExportRecipe_Llama-3.2-1B_Vulkan_Backend_Instruct.ipynb
+++ b/docs/notebooks/ExportRecipe_Llama-3.2-1B_Vulkan_Backend_Instruct.ipynb
@@ -1,0 +1,115 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "ZOq6nHdVElC6"
+      },
+      "source": [
+        "**Step 1: Setting Up ExecuTorch**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": true,
+        "id": "EWz6sJfRDQKT"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install executorch"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": true,
+        "id": "vhSLDN0sDp9-"
+      },
+      "outputs": [],
+      "source": [
+        "# Installing dependencies for Llama\n",
+        "!pip install transformers accelerate sentencepiece huggingface_hub tiktoken torchtune tokenizers snakeviz lm_eval==0.4.5 blobfile pytorch_tokenizers"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "px0lGiHFErF_"
+      },
+      "source": [
+        "**Step 2. Download Llama 3.2 1B/3B models**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "fKKfjA_KEDnU"
+      },
+      "outputs": [],
+      "source": [
+        "from huggingface_hub import login\n",
+        "login()"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": true,
+        "id": "JJdsEZaSEEFR"
+      },
+      "outputs": [],
+      "source": [
+        "!huggingface-cli download meta-llama/Llama-3.2-1B-Instruct --local-dir /content/models/Llama-3.2-1B-Instruct --local-dir-use-symlinks False"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "id": "XLsl5STwEyEh"
+      },
+      "source": [
+        "**Step 3: Export to ExecuTorch**"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "collapsed": true,
+        "id": "gXLuFtVVEZov"
+      },
+      "outputs": [],
+      "source": [
+        "!cd /content/; python -m executorch.examples.models.llama.export_llama \\\n",
+        "  --model \"llama3_2\" \\\n",
+        "  --checkpoint /content/models/Llama-3.2-1B-Instruct/original/consolidated.00.pth \\\n",
+        "  --params /content/models/Llama-3.2-1B-Instruct/original/params.json \\\n",
+        "  -kv \\\n",
+        "  --use_sdpa_with_kv_cache \\\n",
+        "  --vulkan \\\n",
+        "  -d fp32 \\\n",
+        "  --metadata '{\"get_bos_id\":128000, \"get_eos_ids\":[128009, 128001]}' \\\n",
+        "  --output_name=\"Llama-3.2-1B-Instruct_vulkan_fp32.pte\""
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ spotless = "7.1.0"
 kotlinxSerializationJson = "1.8.1"
 kotlinxSerializationPlugin = "2.2.0"
 onnxRuntime = "1.23.2"
-executorch = "0.7.0"
+executorch = "1.0.0"
 mediapipeTasksText = "0.10.26"
 mediapipeTasksGenai = "0.10.25"
 
@@ -48,7 +48,10 @@ kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-
 # Docs: https://onnxruntime.ai/docs/build/android.html#qnn-execution-provider
 onnxruntime-android = { group = "com.microsoft.onnxruntime", name = "onnxruntime-android", version.ref = "onnxRuntime" }
 # ExecuTorch.
-executorch-android = { group = "org.pytorch", name = "executorch-android", version.ref = "executorch" }
+# The standard build is "executorch-android".
+# The `-vulkan` build includes Vulkan backend in addition to XnnpackBackend.
+# Docs: https://docs.pytorch.org/executorch/1.0/using-executorch-android.html
+executorch-android = { group = "org.pytorch", name = "executorch-android-vulkan", version.ref = "executorch" }
 # MediaPipe (LiteRT).
 mediapipe-tasks-text = { group = "com.google.mediapipe", name = "tasks-text", version.ref = "mediapipeTasksText" }
 mediapipe-tasks-genai = { group = "com.google.mediapipe", name = "tasks-genai", version.ref = "mediapipeTasksGenai" }


### PR DESCRIPTION
- update the ExecuTorch dependency to the latest stable release 1.0.0
- update to use "executorch-android-vulkan" build
- add an example to show how to create pte for vulkan backend